### PR TITLE
Repaired errors introduced by previous commits.

### DIFF
--- a/srfi-125.html
+++ b/srfi-125.html
@@ -784,6 +784,8 @@ except that it must accept (and should ignore) an optional second argument.
 <p><small>
 Similar to SRFI 128's <code>string-hash</code> procedure,
 except that it must accept (and should ignore) an optional second argument.
+It is incompatible with the procedure of the same name exported by SRFI 128
+and <http://srfi.schemers.org/srfi-126/srfi-126.html">SRFI 126</a>.
 </small></p>
 <p><small><code>(string-ci-hash </code><em>obj</em><code>)</code></small>
 </p>
@@ -890,7 +892,7 @@ DEALINGS IN THE SOFTWARE.
     <address>Editor: <a href="mailto:srfi-editors at srfi dot schemers dot org">Arthur A. Gleckler</a></address>
 <!--Created: Tue Sep 29 19:20:08 EDT 1998 -->
 <!--hhmts start -->
-Last modified: Sat, May  7, 2016  9:57:02 PM
+Last modified: Sat, May 7, 2016  9:57:02 PM
 <!--hhmts end -->
 
 </body></html>

--- a/srfi/125.sld
+++ b/srfi/125.sld
@@ -21,7 +21,6 @@
    hash-table-intern!
    hash-table-update!
    hash-table-update!/default
-   hash-table-push!
    hash-table-pop!
    hash-table-clear! 
 


### PR DESCRIPTION
Recent changes to the specification were mirrored by changes made in `125.body.scm` but `125.scm` and `tables-test.sps` had not been corrected.  I also added a sentence to the specification that was probably left out of the HTML by accident.
