### PR TITLE
Clarify hash-table-pop! behavior when the table is empty

### DIFF
--- a/srfi-125.html
+++ b/srfi-125.html
@@ -549,6 +549,9 @@ Chooses an arbitrary association from <em>hash-table</em> and removes
 it, returning the key and value as two values.
 </p>
 <p>
+It is an error if <em>hash-table</em> is empty.
+</p>
+<p>
 <code>(hash-table-clear! </code><em>hash-table</em><code>)</code>
 </p>
 <p>

--- a/srfi/125.body.scm
+++ b/srfi/125.body.scm
@@ -366,7 +366,8 @@
         (lambda (key value)
           (hash-table-delete! ht key)
           (return key value))
-        ht))))
+        ht)
+      (error "hash-table-pop!: hash table is empty" ht))))
 
 (define (hash-table-clear! ht)
   (hashtable-clear! ht))


### PR DESCRIPTION
There's no mention what will happen when the table is empty,
which implies it is an error (or 'undefined behavior').  But it's
a bit ambiguous from the current document and reference
implementation---the latter is written in the way that it returns
a single unspecified value when the table is empty.

The suggested change clarify that such operation is an error,
and update the reference implementation to detect the case.

Since it does change the behavior of reference implementation,
as well as the srfi document, it might not be qualified as post-finalization
erratum.  If so, please reject.