### PR TITLE
Fixed bugs reported by Jéssica Milaré.

### DIFF
--- a/srfi/125.body.scm
+++ b/srfi/125.body.scm
@@ -242,14 +242,18 @@
          (error "make-hash-table: unable to infer hash function"
                 equiv))))
 
-;;; FIXME: assumes hash-table-set! goes right to left.
-
 (define (hash-table comparator . rest)
   (let ((ht (apply make-hash-table comparator rest)))
-    (apply hash-table-set!
-           ht
-           rest)
-    ht))
+    (let loop ((kvs rest))
+      (cond
+       ((null? kvs) #f)
+       ((null? (cdr kvs)) (error "hash-table: wrong number of arguments"))
+       ((hashtable-contains? ht (car kvs))
+        (error "hash-table: two equivalent keys were provided"
+               (car kvs)))
+       (else (hashtable-set! ht (car kvs) (cadr kvs))
+             (loop (cddr kvs)))))
+    (hashtable-copy ht #f)))
 
 (define (hash-table-unfold stop? mapper successor seed comparator . rest)
   (let ((ht (apply make-hash-table comparator rest)))
@@ -329,20 +333,23 @@
 (define (hash-table-set! ht . rest)
   (if (= 2 (length rest))
       (hashtable-set! ht (car rest) (cadr rest))
-      (let ((revrest (reverse rest)))
-        (let loop ((revrest revrest))
-          (cond ((and (not (null? revrest))
-                      (not (null? (cdr revrest))))
-                 (hashtable-set! ht (cadr revrest) (car revrest))
-                 (loop (cddr revrest)))
-                ((not (null? revrest))
-                 (error "hash-table-set!: wrong number of arguments"
-                        (cons ht rest))))))))
+      (let loop ((kvs rest))
+        (cond ((and (not (null? kvs))
+                    (not (null? (cdr kvs))))
+               (hashtable-set! ht (car kvs) (cadr kvs))
+               (loop (cddr kvs)))
+              ((not (null? kvs))
+               (error "hash-table-set!: wrong number of arguments"
+                      (cons ht rest)))))))
 
 (define (hash-table-delete! ht . keys)
-  (for-each (lambda (key)
-              (hashtable-delete! ht key))
-            keys))
+  (let loop ((keys keys) (cnt 0))
+    (cond ((null? keys) cnt)
+	  ((hash-table-contains? ht (car keys))
+	   (hashtable-delete! ht (car keys))
+	   (loop (cdr keys) (+ cnt 1)))
+	  (else
+	   (loop (cdr keys) cnt)))))
 
 (define (hash-table-intern! ht key failure)
   (if (hashtable-contains? ht key)
@@ -366,7 +373,8 @@
         (lambda (key value)
           (hash-table-delete! ht key)
           (return key value))
-        ht))))
+        ht)
+      (error "hash-table-pop!: hash table is empty" ht))))
 
 (define (hash-table-clear! ht)
   (hashtable-clear! ht))
@@ -483,9 +491,7 @@
 (define (hash-table-empty-copy ht)
   (let* ((ht2 (hashtable-copy ht #t))
          (ignored (hashtable-clear! ht2)))
-    (if (hashtable-mutable? ht)
-        ht2
-        (hashtable-copy ht2))))
+     ht2))
 
 (define (hash-table->alist ht)
   (call-with-values

--- a/tables-test.sps
+++ b/tables-test.sps
@@ -27,9 +27,9 @@
 (import (scheme base)
         (scheme char)
         (scheme write)
-        (scheme process-context) ; for exit
-        (srfi 128)
-        (r6rs sorting)
+        (only (scheme process-context) exit)
+        (scheme comparator)            ; was (srfi 128)
+        (only (scheme sort) list-sort) ; was (r6rs sorting)
         (rename (srfi 125)
                 (string-hash    deprecated:string-hash)
                 (string-ci-hash deprecated:string-ci-hash)))
@@ -238,7 +238,7 @@
       '(#f #f #t #t #t #t #f #f #f #f #f #f #f #f #f #f))
 
 (test (map hash-table-mutable? test-tables)
-      '(#t #t #t #t #t #t #t #t #t #t #t #t #t #t #t #f))
+      '(#t #f #t #t #t #t #t #t #t #t #t #t #t #t #t #f))
 
 ;;; FIXME: glass-box
 
@@ -819,6 +819,78 @@
         (81 . 9)
         (121 . -11)
         (144 . -12)))
+
+;;; Bugs reported on 5 January 2019 by Jéssica Milaré
+;;; ( https://srfi-email.schemers.org/srfi-125/msg/10177551 )
+
+;;; Spec says hash-table returns an immutable hash table (if that
+;;; is supported) and signal an error if there are duplicate keys,
+;;; but standard implementation returns a mutable hash table and
+;;; signals no error with duplicate keys.
+;;;
+;;; Comment by Will Clinger: the spec says specifying a duplicate
+;;; key "is an error", so hash-table is not required to signal an
+;;; error when there are duplicate keys.  That part of the spec
+;;; was added on 8 May 2016, which is why it was not implemented
+;;; by the sample implementation of 2 May 2016.  Because a duplicate
+;;; key "is an error" rather than "signals an error", testing for
+;;; that situation is glass-box, as is testing for immutability.
+
+;;; FIXME: glass-box
+
+(test (hash-table-mutable?
+       (hash-table number-comparator
+                   .25 .5 64 9999 81 9998 121 -11 144 -12))
+      #f)
+
+;;; FIXME: glass-box (implementations not required to raise an exception here)
+
+(test (guard (exn
+              (else 'eh))
+       (hash-table number-comparator .25 .5 .25 -.5))
+      'eh)
+
+;;; Spec says hash-table-set! must go left to right, but in
+;;; standard implementation it goes right to left.
+;;;
+;;; Comment by Will Clinger: the left-to-right requirement was
+;;; added to the spec on 8 May 2016, which is why it was not
+;;; implemented by the sample implementation of 2 May 2016.
+
+(test (let* ((ht (hash-table-empty-copy ht-eq))
+             (ignored (hash-table-set! ht 'foo 13 'bar 14 'foo 18)))
+        (hash-table-ref ht 'foo))
+      18)
+
+;;; Spec says hash-table-empty-copy returns a mutable hash table,
+;;; but in standard implementation it returns an immutable hash
+;;; table if the given hash table is immutable.
+
+;;; FIXME: glass-box (immutable tables need not be supported)
+
+(test (hash-table-mutable?
+       (hash-table number-comparator))
+      #f)
+
+(test (hash-table-mutable?
+       (hash-table-empty-copy
+        (hash-table-copy (hash-table number-comparator) #f)))
+      #t)
+
+;;; hash-table-delete! seems to loop infinitely once it finds a key.
+;;;
+;;; Comment by Will Clinger: that bug was added by
+;;; commit e17c15203a934ab741300e59619f880f363c2b2f
+;;; on 26 September 2018.  I do not understand the purpose of that
+;;; commit, as its one change appears to have had no substantive
+;;; effect apart from inserting this bug.
+
+(test (let* ((ht
+              (hash-table default-comparator 'foo 1 'bar 2 'baz 3))
+             (ht (hash-table-copy ht #t)))
+        (hash-table-delete! ht 'foo)
+        (hash-table-size ht))
+      2)
 
 (displayln "Done.")
 


### PR DESCRIPTION
Bugs were reported on 5 January 2019 by Jéssica Milaré: https://srfi-email.schemers.org/srfi-125/msg/10177551

The `hash-table-delete!` patch should be examined because, so far as I can tell, commit e17c15203a934ab741300e59619f880f363c2b2f served no purpose apart from introducing the infinite loop that is repaired by this pull request.