### PR TITLE
tests: Fix a test failured caused by the hash-table being immutable.

### DIFF
--- a/tables-test.sps
+++ b/tables-test.sps
@@ -30,6 +30,7 @@
         (only (scheme process-context) exit)
         (scheme comparator)            ; was (srfi 128)
         (only (scheme sort) list-sort) ; was (r6rs sorting)
+        (only (srfi 126) hashtable-copy)
         (rename (srfi 125)
                 (string-hash    deprecated:string-hash)
                 (string-ci-hash deprecated:string-ci-hash)))
@@ -447,7 +448,9 @@
                   '(169 144 121 0 1 4 9 16 25 36 49 64 75 81)))
       '(13 12 11 0 1 2 3 4 5 -1 -1 8 -1 -1))
 
-(let ((ht-eg (hash-table number-comparator 1 1 4 2 9 3 16 4 25 5 64 8)))
+(let ((ht-eg (hashtable-copy (hash-table number-comparator
+                                         1 1 4 2 9 3 16 4 25 5 64 8)
+                             #t)))
   (test (hash-table-delete! ht-eg)
         0)
   (test (hash-table-delete! ht-eg 2 7 2000)


### PR DESCRIPTION
Prior to this fix, the test suite would error with:

  srfi/srfi-126.scm:150:4: In procedure hashtable-delete!:
  Hashtable is immutable. #hash(custom (25 . 5) (16 . 4) (9 . 3) (4 . 2) (64 . 8) (1 . 1))

This is because since commit 08a8611b0300d0fbc2ab3ac6e4a4fc460836afd6, hash-table now returns an immutable copy by default.

* tables-test.sps: Make a mutable copy for the hash-table-delete! test.