### PR TITLE
Comply with REUSE version 3.0 for licensing declaration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2015 Arthur A. Gleckler <srfi@speechcode.com>
+#
+# SPDX-License-Identifier: MIT
+
 *~

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,10 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: SRFI 125
+Upstream-Contact: Arthur A. Gleckler <srfi-editors@srfi.schemers.org>
+Source: https://github.com/scheme-requests-for-implementation/srfi-125
+
+# Sample paragraph, commented out:
+#
+# Files: src/*
+# Copyright: $YEAR $NAME <$CONTACT>
+# License: ...

--- a/LICENSES/LicenseRef-Clinger.txt
+++ b/LICENSES/LicenseRef-Clinger.txt
@@ -1,0 +1,10 @@
+Copyright 2015 William D Clinger.
+
+Permission to copy this software, in whole or in part, to use this
+software for any lawful purpose, and to redistribute this software
+is granted subject to the restriction that all copies made of this
+software must include this copyright and permission notice in full.
+
+I also request that you send me a copy of any improvements that you
+make to this software so that they may be incorporated within it to
+the benefit of the Scheme community.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.org
+++ b/README.org
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2015 John Cowan
+#
+# SPDX-License-Identifier: MIT
 
 * SRFI 125: Intermediate hash tables
 

--- a/index.html
+++ b/index.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2015 John Cowan
+
+SPDX-License-Identifier: MIT
+-->
+
 <!DOCTYPE html>
 <html>
     <head>

--- a/srfi-125.html
+++ b/srfi-125.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2015 John Cowan
+
+SPDX-License-Identifier: MIT
+-->
+
 <html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <title>SRFI 125: Intermediate hash tables</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/srfi/125.body.scm
+++ b/srfi/125.body.scm
@@ -1,3 +1,4 @@
+;;; SPDX-License-Identifier: LicenseRef-Clinger
 ;;; Copyright 2015 William D Clinger.
 ;;;
 ;;; Permission to copy this software, in whole or in part, to use this

--- a/srfi/125.sld
+++ b/srfi/125.sld
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2015 William D Clinger <will@ccs.neu.edu>
+;;;
+;;; SPDX-License-Identifier: LicenseRef-Clinger
+
 (define-library (srfi 125)
 
   (export

--- a/tables-test.sps
+++ b/tables-test.sps
@@ -1,3 +1,4 @@
+;;; SPDX-License-Identifier: MIT
 ;;; Copyright (C) William D Clinger 2015. All Rights Reserved.
 ;;;
 ;;; Permission is hereby granted, free of charge, to any person


### PR DESCRIPTION
The custom, ethical license text is replaced by the plain Expat license text (identified as 'MIT' in the SPDX standard).  I think this license text wasn't compatible with a free software license such as Expat (MIT) as it imposed conditions on use ("for any lawful purpose").

We'll want to confirm that Will agrees to this before merging.