### PR TITLE
srfi/125.sld: conform "rename" clause to r6rs

### DIFF
--- a/srfi/125.sld
+++ b/srfi/125.sld
@@ -53,19 +53,18 @@
 
    ;; The following procedures are deprecated by SRFI 125:
 
-   (rename deprecated:hash                     hash)
-   (rename deprecated:string-hash              string-hash)
-   (rename deprecated:string-ci-hash           string-ci-hash)
-   (rename deprecated:hash-by-identity         hash-by-identity)
-
-   (rename deprecated:hash-table-equivalence-function
-                                               hash-table-equivalence-function)
-   (rename deprecated:hash-table-hash-function hash-table-hash-function)
-   (rename deprecated:hash-table-exists?       hash-table-exists?)
-   (rename deprecated:hash-table-walk          hash-table-walk)
-   (rename deprecated:hash-table-merge!        hash-table-merge!)
-
-   )
+   (rename
+    (deprecated:hash                            hash)
+    (deprecated:string-hash                     string-hash)
+    (deprecated:string-ci-hash                  string-ci-hash)
+    (deprecated:hash-by-identity                hash-by-identity)
+    (deprecated:string-ci-hash                  string-ci-hash)
+    (deprecated:hash-by-identity                hash-by-identity)
+    (deprecated:hash-table-equivalence-function hash-table-equivalence-function)
+    (deprecated:hash-table-hash-function        hash-table-hash-function)
+    (deprecated:hash-table-exists?              hash-table-exists?)
+    (deprecated:hash-table-walk                 hash-table-walk)
+    (deprecated:hash-table-merge!               hash-table-merge!)))
 
   (import (scheme base)
           (scheme write) ; for warnings about deprecated features


### PR DESCRIPTION
The "rename" clause was broken. Wouldn't work in guile scheme and I think it's just doesn't conform to r6rs. 
Fix introduced.